### PR TITLE
*: fix FromAsCasing lint for Dockerfiles

### DIFF
--- a/cmd/consumer/Dockerfile
+++ b/cmd/consumer/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -trimpath ./cmd/consumer
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM debian:stable-slim

--- a/cmd/lister/Dockerfile
+++ b/cmd/lister/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -trimpath ./cmd/lister
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM debian:stable-slim

--- a/cmd/pds-discovery/Dockerfile
+++ b/cmd/pds-discovery/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -trimpath ./cmd/pds-discovery
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM debian:stable-slim

--- a/cmd/record-indexer/Dockerfile
+++ b/cmd/record-indexer/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -trimpath ./cmd/record-indexer
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM debian:stable-slim

--- a/cmd/update-db-schema/Dockerfile
+++ b/cmd/update-db-schema/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.22.3 as builder
+FROM golang:1.22.3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN go build -trimpath ./cmd/update-db-schema
 
-FROM alpine:latest as certs
+FROM alpine:latest AS certs
 RUN apk --update add ca-certificates
 
 FROM debian:stable-slim


### PR DESCRIPTION
This fixes this lint: https://docs.docker.com/reference/build-checks/from-as-casing/
which keeps popping up when you run `docker compose build`.

On an unrelated note, the forking situation is pretty cursed now: I used to have a fork of just plc-mirror, forked from https://github.com/bsky-watch/plc-mirror to my account. Because of that, I couldn't create a fork of this repository, because I already had a fork, kinda... and I didn't figure out how to create a PR from a repository not explicitly marked as a fork.