### PR TITLE
cmd/record-indexer: fix typo

### DIFF
--- a/cmd/record-indexer/metrics.go
+++ b/cmd/record-indexer/metrics.go
@@ -12,7 +12,7 @@ var reposQueued = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "Number of repos added to the queue",
 })
 
-var queueLenght = promauto.NewGaugeVec(prometheus.GaugeOpts{
+var queueLength = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "indexer_queue_length",
 	Help: "Current length of indexing queue",
 }, []string{"state"})

--- a/cmd/record-indexer/scheduler.go
+++ b/cmd/record-indexer/scheduler.go
@@ -189,8 +189,8 @@ func (s *Scheduler) fillQueue(ctx context.Context) error {
 
 func (s *Scheduler) updateQueueLenMetrics() {
 	s.mu.Lock()
-	queueLenght.WithLabelValues("queued").Set(float64(len(s.queue)))
-	queueLenght.WithLabelValues("inProgress").Set(float64(len(s.inProgress)))
+	queueLength.WithLabelValues("queued").Set(float64(len(s.queue)))
+	queueLength.WithLabelValues("inProgress").Set(float64(len(s.inProgress)))
 	s.mu.Unlock()
 }
 


### PR DESCRIPTION
Just a typo, but I had this stashed for ages, apparently.